### PR TITLE
add meetups section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Google's Introduction to Web Accessibility https://webaccessibility.withgoogle.c
 - State of Texas Creating Accessible Microsoft Office Documents https://gov.texas.gov/organization/disabilities/accessibledocs
 
 
+## Meetups
+- Chicago Digital Accessibility and Inclusive Design https://www.meetup.com/a11ychi/
+- Seattle Area Accessibility & Inclusive Design https://www.meetup.com/a11ysea/
+- Boston Accessibility https://www.meetup.com/a11yBos/
+- role=drinks https://www.roledrinks.com/
+
+
 ### For More Information
 We've added books, tutorials & blogs here https://github.com/mgifford/a11y-courses/blob/master/Reading-Material.md
 


### PR DESCRIPTION
At first I was thinking these could be added to conferences and events, but decided against that in favor of their own section.

Since the list is small for now, I think it's OK to keep them in the main readme, but I could see this potentially getting their own markdown file, like books, blogs etc.

So, with all that said, the purpose of this PR is to get other opinions on the placement of these.  Accept and merge into the current readme, or deny and make their own markdown file?

Thanks!